### PR TITLE
ci: Travis: test py27, py35, py36, py37, and py38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
-  - "3.4"
-  - "nightly"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - "python setup.py develop"
   - "pip install ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 install:
   - "python setup.py develop"
   - "pip install ."
-  - "pip install pytest coveralls"
+  - "pip install -U pytest coveralls"
 script:
   coverage run --source=smalluuid runtests.py
 after_success:


### PR DESCRIPTION
(currently supported versions)

This should show an error with py38, fixed by #2.